### PR TITLE
Fix assignment of measurement ID parameter

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -91,7 +91,7 @@ func (c *client) DeleteNodeData(ctx context.Context, nodeID uuid.UUID, deleteNod
 
 func (c *client) GetMeasurement(ctx context.Context, measurementID uuid.UUID) (models.ModelMeasurementResponse, error) {
 	request := rest.Get("node-data/{measurementID}").
-		Assign("measurementID", measurementID.String).
+		Assign("measurementID", measurementID.String()).
 		SetHeader("Accept", "application/json")
 
 	var response models.ModelMeasurementResponse


### PR DESCRIPTION
The measurement ID was assigned incorrectly when fetching a measurement by ID. The pointer to the string function was passed instead of the actual parameter.