### PR TITLE
Add function for verbose post node data

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -89,7 +89,7 @@ func (c *client) PostNodeData(ctx context.Context, nodeData []models.ModelNodeDa
 // PostNodeDataVerbose does not guarantee that the returned measurement ID
 // exists. Do not use this functionality in production use cases.
 func (c *client) PostNodeDataVerbose(ctx context.Context, nodeData []models.ModelNodeDataRequest) (models.ModelIngestNodeDataResponse, error) {
-	request := rest.Post("/node-data?{verbose}").
+	request := rest.Post("/node-data{?verbose}").
 		SetHeader("Accept", "application/json").
 		Assign("verbose", "true").
 		WithJSONPayload(nodeData)


### PR DESCRIPTION
The verbose query parameter is optional when posting node data. Setting it to true will result in 202 Accepted being returned with a response body containing the measurement IDs of the ingested measurements.

This is mostly used in testing scenarios when the measurement ID is needed for further test verification.

Due to how data ingestion works in the API the returned measurement ID is not guaranteed to exists. Clients should not rely on this in any production use cases.