### PR TITLE
Fix URL for GET measurement by ID

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -117,7 +117,7 @@ func (c *client) DeleteNodeData(ctx context.Context, nodeID uuid.UUID, deleteNod
 }
 
 func (c *client) GetMeasurement(ctx context.Context, measurementID uuid.UUID, contentType string, excludeCoordinates bool) (models.ModelMeasurementResponse, error) {
-	request := rest.Get("node-data/{measurementID}/{?exclude_coordinates,contentType}").
+	request := rest.Get("node-data/{measurementID}{?exclude_coordinates,contentType}").
 		SetHeader("Accept", "application/json").
 		Assign("measurementID", measurementID.String()).
 		Assign("exclude_coordinates", excludeCoordinates)


### PR DESCRIPTION
The expanded URL does not match the actual route. There should not be a slash at the end.