### PR TITLE
Actually use pointer receiver for unmarshalling get-last-collected-at response

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -166,7 +166,7 @@ func (c *client) GetLastCollectedAt(ctx context.Context, nodeID uuid.UUID) (*mod
 	}
 
 	var response models.ModelStringResponse
-	if err := httpResponse.Unmarshal(response); err != nil {
+	if err := httpResponse.Unmarshal(&response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal last collected at response: %w", err)
 	}
 


### PR DESCRIPTION
Turns out that last-collected-at never worked